### PR TITLE
Fix named parameter check

### DIFF
--- a/ExchangePSAutomationTest/FormMain.cs
+++ b/ExchangePSAutomationTest/FormMain.cs
@@ -419,7 +419,7 @@ namespace ExchangePSAutomationTest
             command.AddCommand(commandLine.Substring(0, i));
             string parameters = commandLine.Substring(i+1);
 
-            i = parameters.IndexOf("-", i);
+            i = parameters.IndexOf("-");
             if (i<0)
             {
                 // We have parameters, but they are not named - we just add them to the command


### PR DESCRIPTION
Removed startIndex argument in parameters.IndexOf("-", i) which causes "-" leading dash not to be found.
Likely initial check was commandLine.IndexOf("-", i) and startIndex parameter was overseen when changed to parameters.IndexOf ...