### PR TITLE
Fix named parameter value retrieval

### DIFF
--- a/ExchangePSAutomationTest/FormMain.cs
+++ b/ExchangePSAutomationTest/FormMain.cs
@@ -430,13 +430,13 @@ namespace ExchangePSAutomationTest
             // Now parse and add parameters
             try
             {
-                while ((i > 0) && (i < commandLine.Length))
+                while ((i > 0) && (i < parameters.Length))
                 {
                     int j = parameters.IndexOf("-", i + 1);
                     if (j < 0) j = parameters.Length;
                     int p = parameters.IndexOf(" ", i + 1);
                     string sParamName = parameters.Substring(i + 1, p - i - 1);
-                    string sParamValue = parameters.Substring(p + 1, j - p - 2).Trim();
+                    string sParamValue = parameters.Substring(p + 1, j - p - 1).Trim();
                     if (sParamValue.StartsWith("\"") && sParamValue.EndsWith("\""))
                         sParamValue = sParamValue.Substring(1, sParamValue.Length - 2);
                     command.AddParameter(sParamName, sParamValue);


### PR DESCRIPTION
Use parameters variable instead of commandLine to iterate over PS parameters.
Substring length "j - p - 2" cuts last character of last (or single) parameter, so changed "j - p - 1".